### PR TITLE
chore: fix cmake deprecation warning

### DIFF
--- a/ros_gazebo_gym_panda_example/CMakeLists.txt
+++ b/ros_gazebo_gym_panda_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 project(ros_gazebo_gym_panda_example)
 
 add_definitions(-std=c++11)


### PR DESCRIPTION
This commit fixes the cmake min version < 3.5 deprecation warning.
