### PR TITLE
fix: update gymnasium-(robotics) rosdep rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,14 @@ project(ros_gazebo_gym_examples)
 add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  ros_gazebo_gym
   rospy
 )
 
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ros_gazebo_gym_examples
-#  CATKIN_DEPENDS ros_gazebo_gym rospy
+  CATKIN_DEPENDS
+    ros_gazebo_gym rospy
 #  DEPENDS system_lib
 )
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "description": "Several usage examples for gymnasium environments found in the ros-gazebo-gym package.",
   "keywords": [
-    "reinforcement-learning",
+    "reinforcement learning",
     "RL",
     "robotics",
     "simulation",
@@ -15,7 +15,7 @@
     "ros",
     "gazebo",
     "environments",
-    "ros_gazebo_gym",
+    "ros-gazebo-gym",
     "panda",
     "emika-franka",
     "examples"

--- a/package.xml
+++ b/package.xml
@@ -8,15 +8,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>ros_gazebo_gym</build_depend>
   <build_depend>rospy</build_depend>
 
   <exec_depend>ros_gazebo_gym</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>franka_gazebo</exec_depend>
 
-  <!-- Python dependencies -->
-  <exec_depend>gymnasium-pip</exec_depend>
+  <!-- Python pip dependencies -->
+  <exec_depend>python-gymnasium-pip</exec_depend>
+  <exec_depend>python-gymnasium-robotics-pip</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-stable-baselines3-pip</exec_depend>
 </package>

--- a/rosdep/README.md
+++ b/rosdep/README.md
@@ -1,0 +1,22 @@
+# Custom ros-gazebo-gym rosdep rules
+
+This README describes how to use the [custom rosdep rules](https://github.com/rickstaa/ros-gazebo-gym/tree/noetic/rosdep/rosdep.yaml) of the `ros-gazebo-gym` package. These rules were created to resolve conflicting requirements between the `python3-gymnasium-pip` and `python3-gymnasium-robotics` rules and the `python3-numpy` rule on [Ubuntu 20.04](https://releases.ubuntu.com/focal/). Specifically, `gymnasium` requires `numpy>=1.20.1`, but the `python3-numpy` rule installs `numpy==1.17.4` (see https://github.com/ros/rosdistro/issues/38332).
+
+> \[!IMPORTANT]\
+> While the steps provided here will work, it is recommended that you use a virtual environment to keep your ROS system packages separate from your project-specific packages. This can help avoid conflicts and ensure reproducibility. To create a virtual environment, you can use the [venv](https://docs.python.org/3/library/venv.html) package and install the correct Numpy, gymnasium and gymnasium-robotics versions directly using [pip](https://pypi.org/project/pip/). When creating the virtual environment, include the `--system-site-packages` flag so that the ROS system packages are available in the virtual environment.
+
+## Usage
+
+To use these rules, follow these steps:
+
+1.  Copy or download the `19-ros-gazebo-gym.list` file from [ros-gazebo-gym/rosdep/19-ros-gazebo-gym.list](https://github.com/rickstaa/ros-gazebo-gym/tree/noetic/rosdep/19-ros-gazebo-gym.list) to the `/etc/ros/rosdep/sources.list.d/` folder.
+2.  Run `rosdep update` to update the rosdep database.
+3.  Run `rosdep install --reinstall ros-gazebo-gym` to install the dependencies of the `ros-gazebo-gym` package. Note that the `--reinstall` flag is necessary because `python3-numpy` is already installed when ROS is installed.
+
+## Restoring Default Rules
+
+If you want to restore the default rules, follow these steps:
+
+1.  Remove the [19-ros-gazebo-gym.list](https://github.com/rickstaa/ros-gazebo-gym/tree/noetic/rosdep/19-ros-gazebo-gym.list) file from the `/etc/ros/rosdep/sources.list.d/` folder.
+2.  Run `rosdep update` to update the rosdep database.
+3.  Run `rosdep install --reinstall ros-gazebo-gym` to install the dependencies of the `ros-gazebo-gym` package. Note that the `--reinstall` flag is necessary because `python3-numpy` is already installed when ROS is installed.


### PR DESCRIPTION
This pull request adds updated [gymnasium](https://gymnasium.farama.org/) and [gymnasium-robotics](https://robotics.farama.org/index.html) rosdep rules to the repository. It also adds a simple readme to explain how to fix system dependency conflicts on Ubuntu 20.04.

> [!important]\
> Should be merged after https://github.com/ros/rosdistro/pull/38341, https://github.com/ros/rosdistro/pull/38244 and .